### PR TITLE
Add default comment for find* queries with call method info

### DIFF
--- a/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/BsonDocumentSyntax.scala
+++ b/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/BsonDocumentSyntax.scala
@@ -1,0 +1,15 @@
+package io.kinoplan.utils.reactivemongo.base
+
+import reactivemongo.api.bson.BSONDocument
+
+trait BsonDocumentSyntax {
+
+  implicit class BSONDocumentOps(document: BSONDocument) {
+
+    def commentQuery(implicit
+      enclosing: sourcecode.Enclosing
+    ): BSONDocument = document ++ BSONDocument("$comment" -> QueryComment.make)
+
+  }
+
+}

--- a/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryBuilderSyntax.scala
+++ b/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryBuilderSyntax.scala
@@ -24,13 +24,6 @@ private[utils] trait QueryBuilderSyntax {
       builderWithReadConcern.cursor[T](readPreference).collect[List](limit, err)
     }
 
-    def withSelfComment()(implicit
-      enclosing: sourcecode.Enclosing.Machine
-    ): BSONCollection#QueryBuilder = {
-      val comment = s"requested by ${enclosing.value}"
-      builder.comment(comment)
-    }
-
   }
 
 }

--- a/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryBuilderSyntax.scala
+++ b/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryBuilderSyntax.scala
@@ -24,6 +24,13 @@ private[utils] trait QueryBuilderSyntax {
       builderWithReadConcern.cursor[T](readPreference).collect[List](limit, err)
     }
 
+    def withSelfComment()(implicit
+      enclosing: sourcecode.Enclosing.Machine
+    ): BSONCollection#QueryBuilder = {
+      val comment = s"requested by ${enclosing.value}"
+      builder.comment(comment)
+    }
+
   }
 
 }

--- a/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryComment.scala
+++ b/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryComment.scala
@@ -1,0 +1,15 @@
+package io.kinoplan.utils.reactivemongo.base
+
+private[utils] object QueryComment {
+
+  /** @param enclosing
+    *   the name of the nearest enclosing definition: val, class, whatever, prefixed by the names of
+    *   all enclosing classs, traits, objects or packages, defs, vals, vars or lazy vals
+    * @return
+    *   A constructed string with call site info
+    */
+  def make(implicit
+    enclosing: sourcecode.Enclosing
+  ): String = s"requested by $enclosing"
+
+}

--- a/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryComment.scala
+++ b/common/reactivemongo/base/src/main/scala/io/kinoplan/utils/reactivemongo/base/QueryComment.scala
@@ -1,6 +1,6 @@
 package io.kinoplan.utils.reactivemongo.base
 
-private[utils] object QueryComment {
+object QueryComment {
 
   /** @param enclosing
     *   the name of the nearest enclosing definition: val, class, whatever, prefixed by the names of
@@ -10,6 +10,6 @@ private[utils] object QueryComment {
     */
   def make(implicit
     enclosing: sourcecode.Enclosing
-  ): String = s"requested by $enclosing"
+  ): String = s"requested by ${enclosing.value}"
 
 }

--- a/play/reactivemongo/src/main/scala/io/kinoplan/utils/play/reactivemongo/ReactiveMongoDaoBase.scala
+++ b/play/reactivemongo/src/main/scala/io/kinoplan/utils/play/reactivemongo/ReactiveMongoDaoBase.scala
@@ -16,6 +16,7 @@ import reactivemongo.api.bson.collection.BSONCollection
 import reactivemongo.api.indexes.Index
 
 import io.kinoplan.utils.reactivemongo.base.{
+  BsonDocumentSyntax,
   BsonNoneAsNullProducer,
   Queries,
   QueryComment,
@@ -31,7 +32,8 @@ abstract class ReactiveMongoDaoBase[T](
   readPreferenceO: Option[ReadPreference] = None
 )(implicit
   ec: ExecutionContext
-) extends BsonNoneAsNullProducer {
+) extends BsonNoneAsNullProducer
+      with BsonDocumentSyntax {
 
   protected object dao {
 
@@ -246,14 +248,10 @@ abstract class ReactiveMongoDaoBase[T](
       }
       .withDiagnostic
 
-    def getQueryComment(implicit
-      enclosing: sourcecode.Enclosing
-    ): String = QueryComment.make
-
     private def withQueryComment(implicit
       enclosing: sourcecode.Enclosing
     ): Option[String] =
-      if (autoCommentQueries) Some(getQueryComment)
+      if (autoCommentQueries) Some(QueryComment.make)
       else None
 
   }

--- a/play/reactivemongo/src/main/scala/io/kinoplan/utils/play/reactivemongo/ReactiveMongoDaoBase.scala
+++ b/play/reactivemongo/src/main/scala/io/kinoplan/utils/play/reactivemongo/ReactiveMongoDaoBase.scala
@@ -79,7 +79,8 @@ abstract class ReactiveMongoDaoBase[T](
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
       r: BSONDocumentReader[T],
-      position: Position
+      position: Position,
+      enclosing: sourcecode.Enclosing.Machine
     ): Future[List[T]] = findMany(readConcern = readConcern, readPreference = readPreference)
 
     def findMany[M <: T](
@@ -93,7 +94,8 @@ abstract class ReactiveMongoDaoBase[T](
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
       r: BSONDocumentReader[M],
-      position: Position
+      position: Position,
+      enclosing: sourcecode.Enclosing.Machine
     ): Future[List[M]] = collection
       .flatMap {
         Queries
@@ -107,7 +109,8 @@ abstract class ReactiveMongoDaoBase[T](
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
       r: BSONDocumentReader[T],
-      position: Position
+      position: Position,
+      enclosing: sourcecode.Enclosing.Machine
     ): Future[List[T]] = findMany(
       BSONDocument("_id" -> BSONDocument("$in" -> ids)),
       readConcern = readConcern,
@@ -121,7 +124,8 @@ abstract class ReactiveMongoDaoBase[T](
       readPreference: Option[ReadPreference] = readPreferenceO
     )(implicit
       r: BSONDocumentReader[T],
-      position: Position
+      position: Position,
+      enclosing: sourcecode.Enclosing.Machine
     ): Future[Option[T]] = collection
       .flatMap {
         Queries.findOneQ(_)(selector, projection, readConcern, readPreference)
@@ -134,7 +138,8 @@ abstract class ReactiveMongoDaoBase[T](
       readPreference: Option[ReadPreference] = readPreferenceO
     )(implicit
       r: BSONDocumentReader[T],
-      position: Position
+      position: Position,
+      enclosing: sourcecode.Enclosing.Machine
     ): Future[Option[T]] =
       findOne(BSONDocument("_id" -> id), readConcern = readConcern, readPreference = readPreference)
 
@@ -233,7 +238,8 @@ abstract class ReactiveMongoDaoBase[T](
     readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
   )(implicit
     r: BSONDocumentReader[T],
-    position: Position
+    position: Position,
+    enclosing: sourcecode.Enclosing.Machine
   ): Future[List[T]] = dao.findAll(readConcern, readPreference)
 
   def findManyByIds(
@@ -242,7 +248,8 @@ abstract class ReactiveMongoDaoBase[T](
     readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
   )(implicit
     r: BSONDocumentReader[T],
-    position: Position
+    position: Position,
+    enclosing: sourcecode.Enclosing.Machine
   ): Future[List[T]] = dao.findManyByIds(ids, readConcern, readPreference)
 
   def findOneById(
@@ -251,7 +258,8 @@ abstract class ReactiveMongoDaoBase[T](
     readPreference: Option[ReadPreference] = readPreferenceO
   )(implicit
     r: BSONDocumentReader[T],
-    position: Position
+    position: Position,
+    enclosing: sourcecode.Enclosing.Machine
   ): Future[Option[T]] = dao.findOneById(id, readConcern, readPreference)
 
   def insertMany(values: List[T])(implicit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,6 +43,7 @@ object Dependencies {
   val scalaLogging         = "com.typesafe.scala-logging"    %% "scala-logging"          % "3.9.5"
   val scalastic            = "org.scalactic"                 %% "scalactic"              % "3.2.17"
   val scalatestPlay        = "org.scalatestplus.play"        %% "scalatestplus-play"     % "5.1.0"    % Test
+  val sourcecode           = "com.lihaoyi"                   %% "sourcecode"             % "0.3.1"
   val sttpSlf4jBackend     = "com.softwaremill.sttp.client3" %% "slf4j-backend"          % sttpV
   val tapirServer          = "com.softwaremill.sttp.tapir"   %% "tapir-server"           % tapirV
   val typesafeConfig       = "com.typesafe"                   % "config"                 % "1.4.3"

--- a/project/ModulesCommon.scala
+++ b/project/ModulesCommon.scala
@@ -50,7 +50,9 @@ object ModulesCommon {
   lazy val reactivemongoBaseProfile: Project => Project = _
     .configure(ProjectSettings.commonProfile)
     .settings(name := "utils-reactivemongo-base")
-    .settings(libraryDependencies ++= Seq(Dependencies.reactiveMongo % Provided))
+    .settings(
+      libraryDependencies ++= Seq(Dependencies.reactiveMongo % Provided, Dependencies.sourcecode)
+    )
 
   lazy val reactivemongoBsonAnyProfile: Project => Project = _
     .configure(ProjectSettings.commonProfile)

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoDaoBase.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoDaoBase.scala
@@ -76,7 +76,8 @@ abstract class ReactiveMongoDaoBase[T](
       readConcern: Option[ReadConcern] = None,
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
-      r: BSONDocumentReader[T]
+      r: BSONDocumentReader[T],
+      enclosing: sourcecode.Enclosing.Machine
     ): Task[List[T]] = findMany(readConcern = readConcern, readPreference = readPreference)
 
     def findMany[M <: T](
@@ -89,7 +90,8 @@ abstract class ReactiveMongoDaoBase[T](
       readConcern: Option[ReadConcern] = None,
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
-      r: BSONDocumentReader[M]
+      r: BSONDocumentReader[M],
+      enclosing: sourcecode.Enclosing.Machine
     ): Task[List[M]] = for {
       coll <- collection
       result <- ZIO.fromFuture(implicit ec =>
@@ -111,7 +113,8 @@ abstract class ReactiveMongoDaoBase[T](
       readConcern: Option[ReadConcern] = None,
       readPreference: ReadPreference = readPreferenceO.getOrElse(ReadPreference.secondaryPreferred)
     )(implicit
-      r: BSONDocumentReader[T]
+      r: BSONDocumentReader[T],
+      enclosing: sourcecode.Enclosing.Machine
     ): Task[List[T]] = findMany(
       BSONDocument("_id" -> BSONDocument("$in" -> ids)),
       readConcern = readConcern,
@@ -124,7 +127,8 @@ abstract class ReactiveMongoDaoBase[T](
       readConcern: Option[ReadConcern] = None,
       readPreference: Option[ReadPreference] = readPreferenceO
     )(implicit
-      r: BSONDocumentReader[T]
+      r: BSONDocumentReader[T],
+      enclosing: sourcecode.Enclosing.Machine
     ): Task[Option[T]] = for {
       coll <- collection
       result <- ZIO.fromFuture(implicit ec =>
@@ -137,7 +141,8 @@ abstract class ReactiveMongoDaoBase[T](
       readConcern: Option[ReadConcern] = None,
       readPreference: Option[ReadPreference] = readPreferenceO
     )(implicit
-      r: BSONDocumentReader[T]
+      r: BSONDocumentReader[T],
+      enclosing: sourcecode.Enclosing.Machine
     ): Task[Option[T]] =
       findOne(BSONDocument("_id" -> id), readConcern = readConcern, readPreference = readPreference)
 

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoDaoBase.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoDaoBase.scala
@@ -8,6 +8,7 @@ import reactivemongo.api.indexes.Index
 import zio.{Task, Unsafe, ZIO}
 
 import io.kinoplan.utils.reactivemongo.base.{
+  BsonDocumentSyntax,
   BsonNoneAsNullProducer,
   Queries,
   QueryComment,
@@ -20,7 +21,8 @@ abstract class ReactiveMongoDaoBase[T](
   autoCommentQueries: Boolean = true,
   failoverStrategyO: Option[FailoverStrategy] = None,
   readPreferenceO: Option[ReadPreference] = None
-) extends BsonNoneAsNullProducer {
+) extends BsonNoneAsNullProducer
+      with BsonDocumentSyntax {
 
   protected object dao {
 
@@ -260,14 +262,10 @@ abstract class ReactiveMongoDaoBase[T](
       )
     } yield ()
 
-    def getQueryComment(implicit
-      enclosing: sourcecode.Enclosing
-    ): String = QueryComment.make(enclosing)
-
     private def withQueryComment(implicit
       enclosing: sourcecode.Enclosing
     ): Option[String] =
-      if (autoCommentQueries) Some(getQueryComment)
+      if (autoCommentQueries) Some(QueryComment.make)
       else None
 
   }


### PR DESCRIPTION
Использовал библиотеку [sourcecode](https://github.com/com-lihaoyi/sourcecode) для получение информации о вызывающем методе. По сути идея из нее используется в основе Scalastic. Но в sourcecode больше функциональности. 

Выбрал sourcecode.Enclosing.Machine для добавления comment, так как дает максимум необходимой информации, по которой можно потом отыскать вызывающий метод. 

> sourcecode.Enclosing: the name of the nearest enclosing definition: val, class, whatever, prefixed by the names of all enclosing classs, traits, objects or packages, defs, vals, vars or lazy vals

Из моментов, вызывающих сомнения:

- Стоит ли ограничить длину комментария, вроде в монге нет с этим проблем, но мало ли;
- Стоит ли добавить настройку в конфиг, чтобы включать-выключать функциональность;
- Что делать с методами аггрегации, возможно стоит добавить метод, который генерирует комментарий, чтобы можно было его просто использовать в рукописных методах