### PR TITLE
Add metrics to zio ReactiveMongoDaoBase

### DIFF
--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoOperations.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoOperations.scala
@@ -15,16 +15,16 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
     w: BSONDocumentWriter[T]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.insertManyQ(coll)(values))
-    _ <- insertCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.insertManyQ(coll)(values)) @@
+      aspect.insertQueryTimer(coll) @@ aspect.insertQueriesCounter(coll)
   } yield result
 
   def insertOne(value: T)(implicit
     w: BSONDocumentWriter[T]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.insertOneQ(coll)(value))
-    _ <- insertCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.insertOneQ(coll)(value)) @@
+      aspect.insertQueryTimer(coll) @@ aspect.insertQueriesCounter(coll)
   } yield result
 
   def update(
@@ -35,56 +35,57 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
     arrayFilters: Seq[BSONDocument] = Seq.empty[BSONDocument]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.updateQ(coll)(q, u, multi, upsert, arrayFilters))
-    _ <- updateCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO
+      .fromFuture(implicit ec => Queries.updateQ(coll)(q, u, multi, upsert, arrayFilters)) @@
+      aspect.updateQueryTimer(coll) @@ aspect.updateQueriesCounter(coll)
   } yield result
 
   def updateMany(values: List[T], f: T => (BSONDocument, BSONDocument, Boolean, Boolean)) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.updateManyQ(coll)(values, f))
-    _ <- updateCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.updateManyQ(coll)(values, f)) @@
+      aspect.updateQueryTimer(coll) @@ aspect.updateQueriesCounter(coll)
   } yield result
 
   def upsert(q: BSONDocument, value: T)(implicit
     w: BSONDocumentWriter[T]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.upsertQ(coll)(q, value))
-    _ <- updateCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.upsertQ(coll)(q, value)) @@
+      aspect.updateQueryTimer(coll) @@ aspect.updateQueriesCounter(coll)
   } yield result
 
   def saveOne(q: BSONDocument, value: T, multi: Boolean = false, upsert: Boolean = true)(implicit
     w: BSONDocumentWriter[T]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.saveQ(coll)(q, value, multi, upsert))
-    _ <- updateCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.saveQ(coll)(q, value, multi, upsert)) @@
+      aspect.updateQueryTimer(coll) @@ aspect.updateQueriesCounter(coll)
   } yield result
 
   def saveMany(values: List[T], f: T => (BSONDocument, T, Boolean, Boolean))(implicit
     w: BSONDocumentWriter[T]
   ) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.saveManyQ(coll)(values, f))
-    _ <- updateCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.saveManyQ(coll)(values, f)) @@
+      aspect.updateQueryTimer(coll) @@ aspect.updateQueriesCounter(coll)
   } yield result
 
   def delete(q: BSONDocument) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.deleteQ(coll)(q))
-    _ <- removeCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.deleteQ(coll)(q)) @@
+      aspect.deleteQueryTimer(coll) @@ aspect.deleteQueriesCounter(coll)
   } yield result
 
   def deleteByIds(ids: Set[BSONObjectID]) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdsQ(coll)(ids))
-    _ <- removeCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdsQ(coll)(ids)) @@
+      aspect.deleteQueryTimer(coll) @@ aspect.deleteQueriesCounter(coll)
   } yield result
 
   def deleteById(id: BSONObjectID) = for {
     coll <- collection
-    result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdQ(coll)(id))
-    _ <- removeCounter.tagged(collectionLabels(coll)).increment
+    result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdQ(coll)(id)) @@
+      aspect.deleteQueryTimer(coll) @@ aspect.deleteQueriesCounter(coll)
   } yield result
 
 }

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoOperations.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/ReactiveMongoOperations.scala
@@ -6,6 +6,7 @@ import reactivemongo.api.bson.collection.BSONCollection
 import zio.{Task, ZIO}
 
 import io.kinoplan.utils.reactivemongo.base.Queries
+import io.kinoplan.utils.zio.reactivemongo.metrics.ReactiveMongoMetric._
 
 class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   def collection: Task[BSONCollection] = coll
@@ -15,6 +16,7 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.insertManyQ(coll)(values))
+    _ <- insertCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def insertOne(value: T)(implicit
@@ -22,6 +24,7 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.insertOneQ(coll)(value))
+    _ <- insertCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def update(
@@ -33,11 +36,13 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.updateQ(coll)(q, u, multi, upsert, arrayFilters))
+    _ <- updateCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def updateMany(values: List[T], f: T => (BSONDocument, BSONDocument, Boolean, Boolean)) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.updateManyQ(coll)(values, f))
+    _ <- updateCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def upsert(q: BSONDocument, value: T)(implicit
@@ -45,6 +50,7 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.upsertQ(coll)(q, value))
+    _ <- updateCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def saveOne(q: BSONDocument, value: T, multi: Boolean = false, upsert: Boolean = true)(implicit
@@ -52,6 +58,7 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.saveQ(coll)(q, value, multi, upsert))
+    _ <- updateCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def saveMany(values: List[T], f: T => (BSONDocument, T, Boolean, Boolean))(implicit
@@ -59,21 +66,25 @@ class ReactiveMongoOperations[T](coll: Task[BSONCollection]) {
   ) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.saveManyQ(coll)(values, f))
+    _ <- updateCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def delete(q: BSONDocument) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.deleteQ(coll)(q))
+    _ <- removeCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def deleteByIds(ids: Set[BSONObjectID]) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdsQ(coll)(ids))
+    _ <- removeCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
   def deleteById(id: BSONObjectID) = for {
     coll <- collection
     result <- ZIO.fromFuture(implicit ec => Queries.deleteByIdQ(coll)(id))
+    _ <- removeCounter.tagged(collectionLabels(coll)).increment
   } yield result
 
 }

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoLabels.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoLabels.scala
@@ -1,0 +1,19 @@
+package io.kinoplan.utils.zio.reactivemongo.metrics
+
+import reactivemongo.api.bson.collection.BSONCollection
+import zio.metrics.MetricLabel
+
+object ReactiveMongoLabels {
+
+  def collectionLabels(collection: BSONCollection): Set[MetricLabel] =
+    Set(MetricLabel("collection", collection.name), MetricLabel("db", collection.db.name))
+
+  private def typeLabel(typeName: String): MetricLabel = MetricLabel("type", typeName)
+
+  val findLabel: MetricLabel = typeLabel("find")
+  val insertLabel: MetricLabel = typeLabel("insert")
+  val updateLabel: MetricLabel = typeLabel("update")
+  val deleteLabel: MetricLabel = typeLabel("delete")
+  val commandLabel: MetricLabel = typeLabel("command")
+
+}

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
@@ -1,34 +1,116 @@
 package io.kinoplan.utils.zio.reactivemongo.metrics
 
+import java.time.temporal.ChronoUnit
+
 import reactivemongo.api.bson.collection.BSONCollection
-import zio.metrics.{Metric, MetricLabel}
+import zio.ZIOAspect
+import zio.metrics.{Metric, MetricKeyType, MetricLabel, MetricState}
 import zio.metrics.Metric.Counter
+
+import io.kinoplan.utils.zio.reactivemongo.metrics.ReactiveMongoLabels._
 
 object ReactiveMongoMetric {
 
   private val PREFIX = "reactive_mongo"
 
-  val findCounter: Counter[Long] = Metric
-    .counter(s"${PREFIX}_find", "Number of completed find queries per db.collection")
+  val queryTimer: Metric[MetricKeyType.Histogram, zio.Duration, MetricState.Histogram] = Metric
+    .timer(
+      s"${PREFIX}_query_duration_seconds",
+      "Tracks the time elapsed between sending a request and receiving a response per type and db.collection.",
+      ChronoUnit.SECONDS
+    )
 
-  val findReceivedDocumentsCounter: Counter[Long] = Metric.counter(
-    s"${PREFIX}_find_response_documents",
-    "Number of total received parsed documents made by ReactiveMongo driver"
+  val queriesCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_queries", "Number of completed queries per type and db.collection.")
+
+  val receivedDocumentsCounter: Counter[Long] = Metric.counter(
+    s"${PREFIX}_received_documents",
+    "Number of received documents per type and db.collection."
   )
 
-  val insertCounter: Counter[Long] = Metric
-    .counter(s"${PREFIX}_insert", "Number of completed insert queries per db.collection")
+  object aspect {
 
-  val updateCounter: Counter[Long] = Metric
-    .counter(s"${PREFIX}_update", "Number of completed update queries per db.collection")
+    def commandQueryTimer(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueryTimerAspect(collection, commandLabel)
 
-  val removeCounter: Counter[Long] = Metric
-    .counter(s"${PREFIX}_remove", "Number of completed remove queries per db.collection")
+    def commandQueriesCounter(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueriesCounterAspect(collection, commandLabel)
 
-  val commandsCounter: Counter[Long] = Metric
-    .counter(s"${PREFIX}_command", "Number of completed commands per db.collection")
+    def commandReceivedDocumentsCounter[In](
+      collection: BSONCollection
+    )(f: In => Long): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In] =
+      mkReceivedDocumentsCounterAspect[In](collection, commandLabel)(f)
 
-  def collectionLabels(collection: BSONCollection): Set[MetricLabel] =
-    Set(MetricLabel("collection", collection.name), MetricLabel("db", collection.db.name))
+    def findQueryTimer(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueryTimerAspect(collection, findLabel)
+
+    def findQueriesCounter(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueriesCounterAspect(collection, findLabel)
+
+    def findReceivedDocumentsCounter[In](
+      collection: BSONCollection
+    )(f: In => Long): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In] =
+      mkReceivedDocumentsCounterAspect[In](collection, findLabel)(f)
+
+    def insertQueryTimer(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueryTimerAspect(collection, insertLabel)
+
+    def insertQueriesCounter(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueriesCounterAspect(collection, insertLabel)
+
+    def updateQueryTimer(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueryTimerAspect(collection, updateLabel)
+
+    def updateQueriesCounter(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueriesCounterAspect(collection, updateLabel)
+
+    def deleteQueryTimer(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueryTimerAspect(collection, deleteLabel)
+
+    def deleteQueriesCounter(
+      collection: BSONCollection
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+      mkQueriesCounterAspect(collection, deleteLabel)
+
+    private def mkQueryTimerAspect(
+      collection: BSONCollection,
+      typeLabel: MetricLabel
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] = queryTimer
+      .tagged(collectionLabels(collection) + typeLabel)
+      .trackDuration
+
+    private def mkQueriesCounterAspect(
+      collection: BSONCollection,
+      typeLabel: MetricLabel
+    ): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] = queriesCounter
+      .tagged(collectionLabels(collection) + typeLabel)
+      .trackSuccessWith[Any](_ => 1L)
+
+    private def mkReceivedDocumentsCounterAspect[In](
+      collection: BSONCollection,
+      typeLabel: MetricLabel
+    )(f: In => Long): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, In] = receivedDocumentsCounter
+      .tagged(collectionLabels(collection) + typeLabel)
+      .trackSuccessWith[In](f)
+
+  }
 
 }

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
@@ -3,7 +3,7 @@ package io.kinoplan.utils.zio.reactivemongo.metrics
 import java.time.temporal.ChronoUnit
 
 import reactivemongo.api.bson.collection.BSONCollection
-import zio.ZIOAspect
+import zio.{Chunk, ZIOAspect}
 import zio.metrics.{Metric, MetricKeyType, MetricLabel, MetricState}
 import zio.metrics.Metric.Counter
 
@@ -17,7 +17,8 @@ object ReactiveMongoMetric {
     .timer(
       s"${PREFIX}_query_duration_seconds",
       "Tracks the time elapsed between sending a request and receiving a response per type and db.collection.",
-      ChronoUnit.SECONDS
+      ChronoUnit.SECONDS,
+      Chunk(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0)
     )
 
   val queriesCounter: Counter[Long] = Metric

--- a/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
+++ b/zio/reactivemongo/src/main/scala/io/kinoplan/utils/zio/reactivemongo/metrics/ReactiveMongoMetric.scala
@@ -1,0 +1,34 @@
+package io.kinoplan.utils.zio.reactivemongo.metrics
+
+import reactivemongo.api.bson.collection.BSONCollection
+import zio.metrics.{Metric, MetricLabel}
+import zio.metrics.Metric.Counter
+
+object ReactiveMongoMetric {
+
+  private val PREFIX = "reactive_mongo"
+
+  val findCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_find", "Number of completed find queries per db.collection")
+
+  val findReceivedDocumentsCounter: Counter[Long] = Metric.counter(
+    s"${PREFIX}_find_response_documents",
+    "Number of total received parsed documents made by ReactiveMongo driver"
+  )
+
+  val insertCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_insert", "Number of completed insert queries per db.collection")
+
+  val updateCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_update", "Number of completed update queries per db.collection")
+
+  val removeCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_remove", "Number of completed remove queries per db.collection")
+
+  val commandsCounter: Counter[Long] = Metric
+    .counter(s"${PREFIX}_command", "Number of completed commands per db.collection")
+
+  def collectionLabels(collection: BSONCollection): Set[MetricLabel] =
+    Set(MetricLabel("collection", collection.name), MetricLabel("db", collection.db.name))
+
+}


### PR DESCRIPTION
Only add metrics to the ZIO module.
resolve:#551

-  Implement counters for the number of requests per collection by common types.
-  Implement a counter for the number of received documents. 

 
All metrics have basic tags such as db, Collection.

Perhaps in the future, all the metrics placed in the underlying Quiries object, like in Tapir, will be implemented differently by ZIO, Kamon. But now it's too much.

Welcome notes about new metrics or their names.