### PR TITLE
Use noSpaces instead of toString for CirceRedisEncoders

### DIFF
--- a/common/redisson/codec/circe/src/main/scala/io/kinoplan/utils/redisson/codec/CirceRedisEncoders.scala
+++ b/common/redisson/codec/circe/src/main/scala/io/kinoplan/utils/redisson/codec/CirceRedisEncoders.scala
@@ -6,5 +6,5 @@ import io.circe.syntax.EncoderOps
 import io.kinoplan.utils.redisson.core.codec.RedisEncoder
 
 trait CirceRedisEncoders {
-  implicit def circeToRedisEncoder[T: Encoder]: RedisEncoder[T] = _.asJson.toString
+  implicit def circeToRedisEncoder[T: Encoder]: RedisEncoder[T] = _.asJson.noSpaces
 }


### PR DESCRIPTION
fixes: #706 