### PR TITLE
Limit db.query.text length in ReactivemongoKamonInstrumentation

### DIFF
--- a/common/reactivemongo/kamon-instrumentation/src/main/resources/reference.conf
+++ b/common/reactivemongo/kamon-instrumentation/src/main/resources/reference.conf
@@ -1,3 +1,9 @@
+kamon.instrumentation.reactivemongo {
+  tracing {
+    max-normalized-query-length = 16384
+  }
+}
+
 kanela {
   modules {
     reactivemongo {

--- a/common/reactivemongo/kamon-instrumentation/src/main/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/Printer.scala
+++ b/common/reactivemongo/kamon-instrumentation/src/main/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/Printer.scala
@@ -1,0 +1,106 @@
+package io.kinoplan.utils.reactivemongo.kamon.instrumentation
+
+import reactivemongo.api.bson._
+
+final case class Printer(ident: String = "  ", maxLength: Int) {
+
+  def print(doc: BSONDocument, initialCapacity: Int = 16): String = {
+    val sb = new StringBuilder(initialCapacity)
+    unsafePrint(
+      doc,
+      name =>
+        if (name.isEmpty) ""
+        else s"'$name': ",
+      sb
+    )
+    sb.result()
+  }
+
+  private def append(sb: StringBuilder, s: String): Boolean =
+    if (sb.length + s.length > maxLength) {
+      val remainingLength = maxLength - sb.length
+      if (remainingLength > 0) sb.append(s.take(remainingLength))
+      true
+    } else {
+      sb.append(s)
+      false
+    }
+
+  private def unsafePrint(doc: BSONDocument, f: String => String, sb: StringBuilder): Boolean =
+    if (doc.elements.isEmpty) append(sb, "{}")
+    else {
+      if (append(sb, "{\n")) return true
+      doc
+        .elements
+        .foreach {
+          case BSONElement((name, value)) =>
+            if (unsafePrint(name, value, 1, ident, f, sb)) return true
+            if (append(sb, ",\n")) return true
+          case _ => ()
+        }
+      sb.delete(sb.size - 2, sb.size)
+      append(sb, "\n}")
+    }
+
+  private def unsafePrint(
+    name: String,
+    value: BSONValue,
+    deep: Int,
+    currentIdent: String,
+    f: String => String,
+    sb: StringBuilder
+  ): Boolean = {
+    if (append(sb, currentIdent)) return true
+    if (append(sb, f(name))) return true
+
+    value match {
+      case BSONDouble(d) => append(sb, d.toString)
+      case s: BSONString => append(sb, BSONString.pretty(s))
+      case BSONArray(vs) =>
+        if (vs.isEmpty) append(sb, "[]")
+        else {
+          if (append(sb, "[\n")) return true
+          vs.foreach { v =>
+            if (unsafePrint("", v, deep + 1, currentIdent + ident, f, sb)) return true
+            if (append(sb, ",\n")) return true
+          }
+          sb.delete(sb.size - 2, sb.size)
+          append(sb, s"\n$currentIdent]")
+        }
+      case BSONDocument(elements) =>
+        if (elements.isEmpty) append(sb, "{}")
+        else {
+          if (append(sb, "{\n")) return true
+          elements.foreach {
+            case BSONElement((name, value)) =>
+              if (unsafePrint(name, value, deep + 1, currentIdent + ident, f, sb)) return true
+              if (append(sb, ",\n")) return true
+            case _ => ()
+          }
+          sb.delete(sb.size - 2, sb.size)
+          append(sb, s"\n$currentIdent}")
+        }
+      case binary: BSONBinary       => append(sb, BSONBinary.pretty(binary))
+      case BSONUndefined            => append(sb, BSONUndefined.pretty)
+      case d: BSONObjectID          => append(sb, BSONObjectID.pretty(d))
+      case BSONBoolean(boolean)     => append(sb, boolean.toString)
+      case time: BSONDateTime       => append(sb, BSONDateTime.pretty(time))
+      case BSONNull                 => append(sb, BSONNull.pretty)
+      case regex: BSONRegex         => append(sb, BSONRegex.pretty(regex))
+      case BSONSymbol(symbol)       => append(sb, symbol)
+      case BSONInteger(i)           => append(sb, i.toString)
+      case timestamp: BSONTimestamp => append(sb, BSONTimestamp.pretty(timestamp))
+      case l: BSONLong              => append(sb, BSONLong.pretty(l))
+      case decimal: BSONDecimal     => append(sb, BSONDecimal.pretty(decimal))
+      case BSONMinKey               => append(sb, BSONMinKey.pretty)
+      case BSONMaxKey               => append(sb, BSONMaxKey.pretty)
+      case _                        => append(sb, value.toString)
+    }
+
+  }
+
+}
+
+object Printer {
+  def withLimit(maxLength: Int): Printer = Printer(maxLength = maxLength)
+}

--- a/common/reactivemongo/kamon-instrumentation/src/main/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/ReactiveMongoClientInstrumentation.scala
+++ b/common/reactivemongo/kamon-instrumentation/src/main/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/ReactiveMongoClientInstrumentation.scala
@@ -1,5 +1,7 @@
 package io.kinoplan.utils.reactivemongo.kamon.instrumentation
 
+import com.typesafe.config.Config
+import kamon.Kamon
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import reactivemongo.api._
 
@@ -10,4 +12,20 @@ class ReactiveMongoClientInstrumentation extends InstrumentationBuilder {
     classOf[MongoConnectionSendExpectingResponseAdvice]
   )
 
+}
+
+object ReactiveMongoClientInstrumentation {
+
+  private val settings: Settings = readSettings(Kamon.config())
+
+  val printer: Printer = Printer.withLimit(settings.maxNormalizedQueryLength)
+
+  private def readSettings(config: Config): Settings = {
+    val reactivemongoConfig = config.getConfig("kamon.instrumentation.reactivemongo")
+    Settings(maxNormalizedQueryLength =
+      reactivemongoConfig.getInt("tracing.max-normalized-query-length")
+    )
+  }
+
+  private case class Settings(maxNormalizedQueryLength: Int)
 }

--- a/common/reactivemongo/kamon-instrumentation/src/test/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/PrinterSpec.scala
+++ b/common/reactivemongo/kamon-instrumentation/src/test/scala/io/kinoplan/utils/reactivemongo/kamon/instrumentation/PrinterSpec.scala
@@ -1,0 +1,25 @@
+package io.kinoplan.utils.reactivemongo.kamon.instrumentation
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import reactivemongo.api.bson.{BSONDocument, document}
+import reactivemongo.api.bson.BSONDocument.pretty
+
+class PrinterSpec extends AnyWordSpec with Matchers {
+
+  val testBSONDocument: BSONDocument = document(
+    "key_1" -> "value_1",
+    "array" -> List(document("elem" -> 1), document("elem" -> 2)),
+    "nested" -> document("nested_key" -> document("nested_key_2" -> "value"))
+  )
+
+  "Printer" should {
+    "return the same as pretty" in {
+      Printer.withLimit(1000).print(testBSONDocument) shouldBe pretty(testBSONDocument)
+    }
+    "return truncated string" in {
+      Printer.withLimit(10).print(testBSONDocument).length shouldBe 10
+    }
+  }
+
+}


### PR DESCRIPTION
Rewritten the default pretty function using StringBuilder (faster up to 4x-7x) with limiting output.