### PR TITLE
Fix for Missing catch of NumberFormatException

### DIFF
--- a/zio/redisson/src/test/scala/io/kinoplan/utils/zio/redisson/helpers/SentinelNatMapper.java
+++ b/zio/redisson/src/test/scala/io/kinoplan/utils/zio/redisson/helpers/SentinelNatMapper.java
@@ -25,16 +25,39 @@ public class SentinelNatMapper {
                 Map<String, ContainerNetwork> ss = node.getContainerInfo().getNetworkSettings().getNetworks();
                 ContainerNetwork s = ss.values().iterator().next();
 
+                String hostPort = null;
+                if (mappedPort != null && mappedPort.length > 0) {
+                    hostPort = mappedPort[0].getHostPortSpec();
+                }
+
                 if (uri.getPort() == port
                         && !uri.getHost().equals("redis")
                         && node.getNetworkAliases().contains("slave")) {
-                    return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
+                    if (hostPort == null || hostPort.isEmpty()) {
+                        continue;
+                    }
+                    try {
+                        int parsedPort = Integer.parseInt(hostPort);
+                        return new RedisURI(uri.getScheme(), "127.0.0.1", parsedPort);
+                    } catch (NumberFormatException e) {
+                        // Skip this node if host port is not a valid integer
+                        continue;
+                    }
                 }
 
                 if (mappedPort != null
                         && s.getIpAddress() != null
                         && s.getIpAddress().equals(uri.getHost())) {
-                    return new RedisURI(uri.getScheme(), "127.0.0.1", Integer.parseInt(mappedPort[0].getHostPortSpec()));
+                    if (hostPort == null || hostPort.isEmpty()) {
+                        continue;
+                    }
+                    try {
+                        int parsedPort = Integer.parseInt(hostPort);
+                        return new RedisURI(uri.getScheme(), "127.0.0.1", parsedPort);
+                    } catch (NumberFormatException e) {
+                        // Skip this node if host port is not a valid integer
+                        continue;
+                    }
                 }
             }
             return uri;


### PR DESCRIPTION
In general, to fix this kind of issue you should avoid calling `Integer.parseInt` on untrusted or potentially non‑numeric strings without handling `NumberFormatException`. Either validate the string before parsing or wrap the parse in a `try`/`catch` and choose a safe fallback or rethrow with context.

Here the best fix with minimal behavioural change is: extract the host port string to a local variable, guard against `null`/empty strings, and then parse it inside a `try`/`catch`. If parsing fails, we can simply skip this mapping attempt and fall through to the default `return uri;`, which keeps the existing observable behaviour of "no mapping" rather than failing the entire call. This needs to be done in both places where `Integer.parseInt(mappedPort[0].getHostPortSpec())` appears (lines 31 and 37). No new imports are required because `NumberFormatException` is in `java.lang`.

Concretely:
- Introduce a local `String hostPort = (mappedPort != null && mappedPort.length > 0) ? mappedPort[0].getHostPortSpec() : null;`.
- Add null/empty checks and a `try`/`catch (NumberFormatException e)` around the `Integer.parseInt` calls.
- In case of failure, `continue;` the loop so other nodes can be checked, or eventually the original `uri` is returned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._